### PR TITLE
update: .vscode/ settings for save-on-format

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,14 @@
 {
-  "go.gopath": "${env:GOPATH}",
-  "go.buildOnSave": "off",
-  "go.lintOnSave": "off",
-  "go.formatTool": "gofmt",
-  "go.installDependenciesWhenBuilding": false
+	"go.gopath": "${env:GOPATH}",
+	"go.buildOnSave": "off",
+	"go.lintOnSave": "workspace",
+	"go.formatTool": "goimports",
+	"go.installDependenciesWhenBuilding": true,
+	"[go]": {
+		"editor.insertSpaces": false,
+		"editor.formatOnSave": true,
+		"editor.codeActionsOnSave": {
+			"source.organizeImports": true
+		}
+	}
 }


### PR DESCRIPTION
* update `.vscode/settings.json`
    * formatTool change from `gofmt` to `goimports` for automatic complement import packages in go files 	